### PR TITLE
Revert "chore: upgrade latest waku sdk, remove relay node"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "@types/jest": "^29.4.0",
         "@types/react": "^18.0.28",
         "@types/testing-library__jest-dom": "^5.14.5",
-        "@typescript-eslint/eslint-plugin": "^7.1.1",
-        "@typescript-eslint/parser": "^7.1.1",
+        "@typescript-eslint/eslint-plugin": "^5.52.0",
         "bundlewatch": "^0.3.3",
         "eslint": "^8.34.0",
         "eslint-config-prettier": "^8.6.0",
@@ -40,8 +39,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "^0.0.22",
-        "@waku/sdk": "^0.0.23",
+        "@waku/interfaces": "^0.0.21",
+        "@waku/sdk": "^0.0.22",
         "react": "^16.8.0 || ^17 || ^18"
       },
       "peerDependenciesMeta": {
@@ -57,6 +56,67 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.13.tgz",
+      "integrity": "sha512-B5GL6ILDek72OjoEyFGEuuNYaEOYxO06Ulhcaf/5iQ4EO8uaZWS+OkolYST7L+ecJrkjfaSNmSAsWRRuh+1Z5A==",
+      "peer": true,
+      "dependencies": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^4.0.1",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/interface": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+      "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+      "peer": true,
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/logger": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.6.tgz",
+      "integrity": "sha512-ofTE3kDivBJnUSoX68nOeg1EuAnIE8oUjUnQnuKrxH+nh0JtjTcvwwIzjmm4nApwb4xj2dgPSDvU38Mjmu3TvA==",
+      "peer": true,
+      "dependencies": {
+        "@libp2p/interface": "^1.1.3",
+        "@multiformats/multiaddr": "^12.1.14",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.10",
+        "multiformats": "^13.0.1"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/@achingbrain/ssdp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.6.tgz",
+      "integrity": "sha512-Y4JE2L9150i50V6lg/Y8+ilhxRpUZKKv+PKo68Aj7MjPfaUAar6ZHilF9h4/Zb3q0fqGMXNc9o11cQLNI8J8bA==",
+      "peer": true,
+      "dependencies": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -767,57 +827,44 @@
       "peer": true
     },
     "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-12.0.0.tgz",
-      "integrity": "sha512-ZuVIvzZjUaZXSPG6Ni9veVBLkZ4OkVp3zc3E8Y5EG/iIUSNVbHLFxweb3HuA12e3lIXLLurvy4vDyGWp4FpKow==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-10.1.1.tgz",
+      "integrity": "sha512-nou65zlGaUIPwlUq7ceEVpszJX4tBWRRanppYaKsJk7rbDeIKRJQla2duATGOI3fwj1+pGSlDQuF2zG7P0VJQw==",
       "peer": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.1",
-        "@libp2p/interface": "^1.1.2",
-        "@libp2p/interface-internal": "^1.0.7",
-        "@libp2p/peer-id": "^4.0.5",
-        "@libp2p/pubsub": "^9.0.8",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/crypto": "^2.0.0",
+        "@libp2p/interface": "^0.1.4",
+        "@libp2p/interface-internal": "^0.1.0",
+        "@libp2p/logger": "^3.0.0",
+        "@libp2p/peer-id": "^3.0.0",
+        "@libp2p/pubsub": "^8.0.0",
+        "@multiformats/multiaddr": "^12.1.3",
+        "abortable-iterator": "^5.0.1",
         "denque": "^2.1.0",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "multiformats": "^13.0.1",
-        "protons-runtime": "5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
+        "it-pushable": "^3.2.0",
+        "multiformats": "^12.0.1",
+        "protobufjs": "^7.2.4",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.4"
       },
       "engines": {
         "npm": ">=8.7.0"
       }
     },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-14.1.0.tgz",
-      "integrity": "sha512-uHmptoxgMsfDIP7cQMQ4Zp9+y27oON5+gloBLXi+7EJpMhyvo7tjafUxRILwLofzeAtfaF3ZHraoXRFUSbhK2Q==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-13.0.5.tgz",
+      "integrity": "sha512-xXqwrkH4nXlv3cYENHtqOgmIT2M4irPDwi548UvpmxzeC9hqa0kmiqbtAFYMV3v+gJ9pqVBVWFRk2hjs83GNrw==",
       "peer": true,
       "dependencies": {
         "@chainsafe/as-chacha20poly1305": "^0.1.0",
         "@chainsafe/as-sha256": "^0.4.1",
-        "@libp2p/crypto": "^3.0.0",
-        "@libp2p/interface": "^1.0.0",
-        "@libp2p/peer-id": "^4.0.0",
+        "@libp2p/crypto": "^2.0.0",
+        "@libp2p/interface": "^0.1.0",
+        "@libp2p/logger": "^3.0.0",
+        "@libp2p/peer-id": "^3.0.0",
         "@noble/ciphers": "^0.4.0",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
@@ -829,7 +876,7 @@
         "it-stream-types": "^2.0.1",
         "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0",
+        "uint8arrays": "^4.0.4",
         "wherearewe": "^2.0.1"
       },
       "engines": {
@@ -871,9 +918,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -894,9 +941,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
+      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -958,13 +1005,13 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
-        "debug": "^4.3.1",
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -985,9 +1032,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1726,77 +1773,48 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "peer": true
     },
-    "node_modules/@libp2p/bootstrap": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-10.0.16.tgz",
-      "integrity": "sha512-ZFuq5OtQfdeZVjfWrJpW/OuPVOuAflu1nzq9g6/UiVfSvBaZtwe8hcMCQDXv21V8fCVsd703sblzkBwBYi17rQ==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.14"
-      }
-    },
     "node_modules/@libp2p/crypto": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-3.0.4.tgz",
-      "integrity": "sha512-FzSwBo+RJOUzdzEwug5ZL4dAGKwEBWTLzj+EmUTHHY6c87+oLh571DQk/w0oYObSD9hYbcKePgSBaZeBx0JaZg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.8.tgz",
+      "integrity": "sha512-8e5fh6bsJNpSjhrggtlm8QF+BERjelJswIjRS69aKgxp24R4z2kDM4pRYPkfQjXJDLNDtqWtKNmePgX23+QJsA==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
+        "@libp2p/interface": "^0.1.6",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
-        "multiformats": "^13.0.0",
+        "multiformats": "^12.0.1",
         "node-forge": "^1.1.0",
         "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/identify": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-1.0.15.tgz",
-      "integrity": "sha512-Pve7UJKbEqN6nMpc2yjUiNvjpVwewixL3iX/bvhHQi9P4/x9zJkDIgncbdSUAXT0VePkJRRqvFJOye9Pdw4zRQ==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-record": "^7.0.10",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-matcher": "^1.1.2",
-        "it-protobuf-stream": "^1.1.2",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2",
-        "wherearewe": "^2.0.1"
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.4.tgz",
-      "integrity": "sha512-gJXQycTF50tI02X/IlReAav4XoGPs3Yr917vNXsTUsZQRzQaPjbvKfXqA5hkLFpZ1lnxQ8wto/EVw4ca4XaL1A==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.6.tgz",
+      "integrity": "sha512-Lzc5cS/hXuoXhuAbVIxJIHLCYmfPcbU0vVgrpMoiP1Qb2Q3ETU4A46GB8s8mWXgSU6tr9RcqerUqzFYD6+OAag==",
       "peer": true,
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.14",
-        "it-pushable": "^3.2.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
         "it-stream-types": "^2.0.1",
-        "multiformats": "^13.1.0",
-        "progress-events": "^1.0.0",
-        "uint8arraylist": "^2.4.8"
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.0.9.tgz",
-      "integrity": "sha512-c5BzjXdRnuI+xjLiPjGMxh6QbU51wEIdz/OrgQqo2dKDjWz3Qu0due9H2wzzB8nvSNWTLHRr1ucVga3SrmbngQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-0.1.12.tgz",
+      "integrity": "sha512-tUZ4hxU8fO4397p/GtXNvAANHiLA/Uxdil90TuNNCnlb+GZijDYEEJiqBfnk2zYAdwm7Q9iO0fVxZCpfoW8B7Q==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@multiformats/multiaddr": "^12.1.14",
-        "uint8arraylist": "^2.4.8"
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@multiformats/multiaddr": "^12.1.5",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "node_modules/@libp2p/interfaces": {
@@ -1809,263 +1827,208 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/logger": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.7.tgz",
-      "integrity": "sha512-oyICns7G18S4eDhbFHUwZ7gLQnZTBVQtUMmMgEmrs8LnQu2GvXADxmQAPPkKtLNSCvRudg4hN3hP04Y+vNvlBQ==",
+    "node_modules/@libp2p/keychain": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-3.0.8.tgz",
+      "integrity": "sha512-+WmW9bN9WE0uKqTG3DVk+zsd9Np63lLS+uYRhncwCGTvg0HKXq1t+i4Xd8KbZvUv7UVakE8aae1oMezW3nS+2g==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-id": "^3.0.6",
+        "interface-datastore": "^8.2.0",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.1.0.tgz",
+      "integrity": "sha512-qJbJBAhxHVsRBtQSOIkSLi0lskUSFjzE+zm0QvoyxzZKSz+mX41mZLbnofPIVOVauoDQ40dXpe7WDUOq8AbiQQ==",
+      "peer": true,
+      "dependencies": {
+        "@libp2p/interface": "^0.1.6",
+        "@multiformats/multiaddr": "^12.1.5",
         "debug": "^4.3.4",
-        "interface-datastore": "^8.2.11",
-        "multiformats": "^13.1.0"
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-10.0.16.tgz",
-      "integrity": "sha512-F5H322kVCkPoM0FKalmyo5HwVQ/c5vKNpw2uLLyr26bqy7/GQMNkKvs88Rv7O2s2OHe7txC9Uwo9mapF/j4LlQ==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-9.0.12.tgz",
+      "integrity": "sha512-ll+fsz9zJ9OW3Z14hN4uh5JDQWIfudp2HTsSKoBiiFnKNY58tMH01iijNtHXGyGiVPmFCPeJf01oPlx0j9OgDQ==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/utils": "^5.2.6",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "abortable-iterator": "^5.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^2.0.2",
+        "it-pushable": "^3.2.0",
         "it-stream-types": "^2.0.1",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "rate-limiter-flexible": "^3.0.0",
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-5.1.4.tgz",
-      "integrity": "sha512-hFK831x8SRQwWO6sZ0PLdLMJdxSw/HFWTZLqwFGsQbgfgBd+Via3Fztb7xe6VRqHpnAwZkVujP+iubAI7AghGg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-4.0.10.tgz",
+      "integrity": "sha512-f0BDv96L2yF9SZ0YXdg41JcGWwPBGZNAoeFGkna38SMFtj00NQWBOwAjqVdhrYVF58ymB0Ci6OfMzYv1XHVj/A==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "it-length-prefixed": "^9.0.4",
-        "it-length-prefixed-stream": "^1.1.6",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "abortable-iterator": "^5.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^2.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.2",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.1.7.tgz",
-      "integrity": "sha512-9XXWSJtC7XvbH32h2bK3fygyzd4B2/JeWzsjX8cUDtO69jKNiVJglB8UqajZBuwLZSOQG5aRNWK4RWXJDrsh/w==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-4.0.11.tgz",
+      "integrity": "sha512-4bHtIm3VfYMm2laRuebkswQukgQmWTUbExnu1sD5vcbI186aCZ7P56QjWyOIMn3XflIoZ0cx9AXX/WuDQSolDA==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7"
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.7.tgz",
-      "integrity": "sha512-kbslH0VBmcHO1Osr/qQlFljPOYuldUC6OdYM5c6Tdy+KFU/W4P9Ouv/4e7o3uX6LtlQ8QqIsZH+/bR6AJxC8Gw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.6.tgz",
+      "integrity": "sha512-iN1Ia5gH2U1V/GOVRmLHmVY6fblxzrOPUoZrMYjHl/K4s+AiI7ym/527WDeQvhQpD7j3TfDwcAYforD2dLGpLw==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "multiformats": "^13.1.0",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/interface": "^0.1.6",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.0.7.tgz",
-      "integrity": "sha512-ueSjkodKPhYw7C0ysRGscY+e9vJ+ixpmJvi5w8vbnOn0ex9cAT+9S7DGL03d8vGMAT3xjEbUsI2GpF17uZ9Rpg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-3.0.11.tgz",
+      "integrity": "sha512-BmXKgeyAGezPyoY/uni95t439+AE0eqEKMxjfkfy2Hv/LcJ9gdR3zjRl7Hzci1O12b+yeVFtYVU8DZtBCcsZjQ==",
       "peer": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@libp2p/peer-id-factory/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-7.0.10.tgz",
-      "integrity": "sha512-njVSa2mMcGqQoCnhmZQOadHIQMsO52wqKO6fP1On8sVRmb9yXNGBkZ+b5pRXjjPzUpJeUmC+/SZHpeLqpdpPMQ==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-6.0.12.tgz",
+      "integrity": "sha512-8IItsbcPeIaFC5QMZD+gGl/dDbwLjE9nrmL7ZAOvMwcfZx+2AVZPN/6nubahO/wQrchpvBYiK3TxaWGnOH8sIA==",
       "peer": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/multiaddr": "^12.1.14",
-        "protons-runtime": "^5.4.0",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/utils": "^4.0.7",
+        "@multiformats/multiaddr": "^12.1.5",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-10.0.11.tgz",
-      "integrity": "sha512-egcEzHRQUTW7mQuLPyN/y0Rtunk8zFoxLdTRNjJTrvQRmkCeLIDZ8VsYB0KF7feA85nbpRFR62dVjN46I65yFA==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-9.0.12.tgz",
+      "integrity": "sha512-rYpUUhvDI7GTfMFWNJ+HQoEOAVOxfp3t0bgJWLvUFKNtULojEk0znKHa6da7hX2KE06wM7ZEMfF23jZCmrwk1g==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-record": "^7.0.10",
-        "@multiformats/multiaddr": "^12.1.14",
-        "interface-datastore": "^8.2.11",
-        "it-all": "^3.0.4",
-        "mortice": "^3.0.4",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@libp2p/ping": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-1.0.12.tgz",
-      "integrity": "sha512-xJjJJO/2HUBLHMNHjgLpGQdYJHDQeLcIqflBIerpoRKNuc8omusTQ2PRrvMZzvK+N7fZYk7tOuBNZ8wWxVSX6w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@multiformats/multiaddr": "^12.1.14",
-        "it-first": "^3.0.4",
-        "it-pipe": "^3.0.1",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@libp2p/ping/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/peer-id-factory": "^3.0.8",
+        "@libp2p/peer-record": "^6.0.9",
+        "@multiformats/multiaddr": "^12.1.5",
+        "interface-datastore": "^8.2.0",
+        "it-all": "^3.0.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/pubsub": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.11.tgz",
-      "integrity": "sha512-LqGjLHF+8owS9Yxlzpuo6sdY2pe5WMVnKePMNzyT05w1xbmLi21GHF2H5t64zQoxG30vOUGiGwKOB32e4UWaHg==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-8.0.14.tgz",
+      "integrity": "sha512-hkNqUC6ef96WxqYFnmG0CKy9Vvb0mum5IrllUypwWiV0iK1zj8PcqO8oyTjLl/waLG56Kuy8CAjahnMov+U3dw==",
       "peer": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/utils": "^5.2.6",
-        "it-length-prefixed": "^9.0.4",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/interface-internal": "^0.1.9",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "abortable-iterator": "^5.0.1",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "multiformats": "^13.1.0",
-        "p-queue": "^8.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@libp2p/pubsub/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "it-pushable": "^3.2.0",
+        "multiformats": "^12.0.1",
+        "p-queue": "^7.3.4",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.2.6.tgz",
-      "integrity": "sha512-2Y2zi2TsyhOl+8TH27YZiEJWfdrKRogTzYRxQUKNTX03izXpUcwGsFLPjK7nR39LzYQrQ8si1Kx2ayA3zk7BKg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-4.0.7.tgz",
+      "integrity": "sha512-xA6mS4II14870/DmmI3GFRWdNwHeOd2QV3ltatpdVmeEQpdn82jjtCzqn45AChjCugFOskOthXnQiWp+FvdKZg==",
       "peer": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/logger": "^4.0.7",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-matcher": "^1.1.2",
-        "delay": "^6.0.0",
-        "get-iterator": "^2.0.1",
-        "is-loopback-addr": "^2.0.2",
-        "it-pushable": "^3.2.3",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-matcher": "^1.0.1",
+        "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^2.0.1",
-        "netmask": "^2.0.2",
-        "p-defer": "^4.0.0",
-        "race-event": "^1.2.0",
-        "race-signal": "^1.0.2",
-        "uint8arraylist": "^2.4.8"
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "node_modules/@libp2p/websockets": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-8.0.16.tgz",
-      "integrity": "sha512-8SNuGCDtjzObIAr05mXaY7kB1Bz85Tda3T3byHpUVvn7IPbkdkGe0NiKB+ZvK7ZJhBL/7FdQZmVp3GBffWWrmg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-7.0.6.tgz",
+      "integrity": "sha512-Hoe6KJMCKkLv00xWtCCZcdcoRX5GoR0ebdsc+PlMPPpPNhkbTa1OH1I8bcLU6VBMaaWLWuTyIZE6rWTu/+k/9g==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-to-uri": "^10.0.1",
-        "@types/ws": "^8.5.10",
-        "it-ws": "^6.1.1",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/logger": "^3.0.2",
+        "@libp2p/utils": "^4.0.3",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "@types/ws": "^8.5.4",
+        "abortable-iterator": "^5.0.1",
+        "it-ws": "^6.0.0",
         "p-defer": "^4.0.0",
         "wherearewe": "^2.0.1",
-        "ws": "^8.16.0"
+        "ws": "^8.12.1"
       }
     },
     "node_modules/@multiformats/mafmt": {
@@ -2093,23 +2056,56 @@
       }
     },
     "node_modules/@multiformats/multiaddr-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.1.2.tgz",
-      "integrity": "sha512-O7hO+TYsweMjNCqTYKYn8iki2GXA46mxmgqnsOb2Wpr6ca4dRGnPldWTai2WwTeZpQyRJ/7GE+N9zPTfP0xE+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.0.1.tgz",
+      "integrity": "sha512-ZzqwTH8tP5Py/k8eNKprO0i6tuwgrbp7KWz+ttxvzkPl43BlU9Yd5joq+M5grCt158rpAc2uhPobzfXgPxW5XQ==",
       "peer": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@multiformats/multiaddr": "^12.0.0",
-        "multiformats": "^13.0.0"
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.0.1.tgz",
-      "integrity": "sha512-RtOBRJucMCzINPytvt1y7tJ2jr4aSKJmv3DF7/C515RJO9+nu9sZHdsk9vn251OtN8k21rAGlIHESt/BSJWAnQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
+      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
       "peer": true,
       "dependencies": {
         "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/@libp2p/interface": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+      "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+      "peer": true,
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -2191,6 +2187,70 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "peer": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "peer": true
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "24.1.0",
@@ -2630,9 +2690,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2663,6 +2723,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "peer": true
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -2670,9 +2736,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2697,9 +2763,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -2721,33 +2787,32 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.1.tgz",
-      "integrity": "sha512-zioDz623d0RHNhvx0eesUmGfIjzrk18nSBC8xewepKXbBvN/7c1qImV7Hg8TI1URTxKax7/zxfxj3Uph8Chcuw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/type-utils": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
-        "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2756,26 +2821,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
-      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2784,16 +2849,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
-      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1"
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2801,25 +2866,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.1.tgz",
-      "integrity": "sha512-5r4RKze6XHEEhlZnJtR3GYeCh1IueUHdbrukV2KSlLXaTjuSfeVF8mZUVPLovidCuZfbVjfhi4c0DNSa/Rdg5g==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "*"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2828,12 +2893,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2841,22 +2906,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
-      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2868,94 +2932,63 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
-      "integrity": "sha512-thOXM89xA03xAE0lW7alstvnyoBUbBX38YtY+zAUcpRPcq9EIhXPuJ0YTv948MbzmKh6e1AUszn5cBFK49Umqg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "semver": "^7.5.4"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
-      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
-    },
     "node_modules/@waku/core": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.27.tgz",
-      "integrity": "sha512-SPUiR0NrbfuHVhvU91Fnhkjnqkk76DBgYkTtjuLoJ7SbRJFYrnUqnSAXVwe2H+kDXq/M+UgUandLAPS6EyH+2A==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.26.tgz",
+      "integrity": "sha512-aarhaFrN/mDKB2tmVUSodMDt9V3CwllKFy8iYsy+fBcK1cBrv6Yj2nnl6PLDDhfxv+bylzS/OKEvEIAJ+be7YA==",
       "peer": true,
       "dependencies": {
-        "@libp2p/ping": "^1.0.11",
         "@noble/hashes": "^1.3.2",
-        "@waku/enr": "^0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/message-hash": "^0.1.11",
+        "@waku/enr": "^0.0.20",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
         "p-event": "^6.0.0",
         "uint8arraylist": "^2.4.3",
@@ -2966,7 +2999,7 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^1.1.2"
+        "libp2p": "^0.46.3"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
@@ -2975,34 +3008,34 @@
       }
     },
     "node_modules/@waku/dns-discovery": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.21.tgz",
-      "integrity": "sha512-l6TVLNiP9HjVrSCWRVP4pKGAADkPzMY2+/tFxnLI1lx3NWmBrkwsEsZHKlfGpdDTT3130nxXkvENcswqWLsc1w==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.20.tgz",
+      "integrity": "sha512-JnzR/B3iT33aWDg75lGkzM+4eXqZP5n/BlnjMyiXCXX+Du4arRveBg+812ZXZVVMQGLiM/aqM/JOPefKbTegOw==",
       "peer": true,
       "dependencies": {
-        "@waku/enr": "0.0.21",
-        "@waku/utils": "0.0.15",
+        "@waku/enr": "0.0.20",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^4.0.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@waku/enr": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.21.tgz",
-      "integrity": "sha512-FnfA7I+MDH5mJF9thS/a/6dTRLO8WF4WRj1/4BisRr9xTxHBq/qqgzGrk5JAWbeX6Befjle3Bi6cYdbSXGvNQw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.20.tgz",
+      "integrity": "sha512-dzTeESBxagggAaJ6xMCEaiB1PdNN+rLFuLF3mC/0iSgb6Ax2nl5lJmSVTsZpdkPuwiv+sZzt5KgaKzjQEvp0QA==",
       "peer": true,
       "dependencies": {
         "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^4.0.0",
-        "@libp2p/peer-id": "^4.0.4",
+        "@libp2p/crypto": "^3.0.2",
+        "@libp2p/peer-id": "^3.0.3",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2"
       },
@@ -3011,72 +3044,74 @@
       }
     },
     "node_modules/@waku/enr/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-3.0.4.tgz",
+      "integrity": "sha512-FzSwBo+RJOUzdzEwug5ZL4dAGKwEBWTLzj+EmUTHHY6c87+oLh571DQk/w0oYObSD9hYbcKePgSBaZeBx0JaZg==",
       "peer": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/interface": "^1.1.1",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "multiformats": "^13.0.0",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@waku/enr/node_modules/@libp2p/interface": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+      "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+      "peer": true,
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@waku/enr/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/@waku/enr/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@waku/interfaces": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.22.tgz",
-      "integrity": "sha512-SbOCqqv4wLkvVMuIppBXzLjyRHw1rnW3lzeIlNJrTwjIQvhIwasUyHIbZ9Wk9hv1ybhx7HmRuWdesWDQn1x0hQ==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.21.tgz",
+      "integrity": "sha512-6QbXx9IEBz9muSzjrnbaoXnjrMQIu1WOUyhMB6ZgOobgGWluwX/WOPuGGCpqvI7p5WhO0gaziphGVLdopdmRyw==",
       "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@waku/local-peer-cache-discovery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@waku/local-peer-cache-discovery/-/local-peer-cache-discovery-1.0.0.tgz",
-      "integrity": "sha512-He3xudQF8cMbQUU2q9nUlinSW8FSwKX51DLwhPhblVVwhrfdmjvfhjCaMaq2YDoA+y88CIqQG0bLxxl5QADpWQ==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.2",
-        "@waku/interfaces": "^0.0.22",
-        "@waku/utils": "^0.0.15"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@waku/message-hash": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.11.tgz",
-      "integrity": "sha512-Z9OYVZtooVLCLr5BXZiCPnrgaucse9jvtlgAXRvV9xupfj24h6qMe94KLdefr8nED75nQuUwpHzaA6u+lXL2wg==",
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.15"
-      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@waku/peer-exchange": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@waku/peer-exchange/-/peer-exchange-0.0.20.tgz",
-      "integrity": "sha512-Tbdw80VAk4Or6sKUX4LPCkuDo4zYB1/6hOLOMbSo1ck7w8ADNkcByyD5W/wVCmE4wM8Yen2Awb/auIsqunM8LQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@waku/peer-exchange/-/peer-exchange-0.0.19.tgz",
+      "integrity": "sha512-T6eGHidBj49Lkw0fy3gKXbdJiyQ/0b6WYp8ZgJUySmtFCMmFQUEECbdHLx5iJFtocYmbGYFt04f+47dhoCyhog==",
       "peer": true,
       "dependencies": {
         "@libp2p/interfaces": "^3.3.2",
-        "@waku/core": "0.0.27",
-        "@waku/enr": "0.0.21",
-        "@waku/interfaces": "0.0.22",
+        "@waku/core": "0.0.26",
+        "@waku/enr": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1"
       },
       "engines": {
@@ -3096,64 +3131,57 @@
       }
     },
     "node_modules/@waku/relay": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.10.tgz",
-      "integrity": "sha512-nrmaUdjRFksGnsY1PFFcKI0Qn7RRCWIP17zK9CObLLocC4MFvchcmw4zWJveATJE1sCxbG97jDWsiA4SZJpGNA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.9.tgz",
+      "integrity": "sha512-BfjPUVh4rIyZ82PPGBhCIv7nnx/WhrqkpkcXmmM38gsRDHDZSNCE28I3ILs2m+IBjBdeaT16BCq0dUVQD84m2A==",
       "peer": true,
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^12.0.0",
+        "@chainsafe/libp2p-gossipsub": "^10.1.1",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.27",
-        "@waku/interfaces": "0.0.22",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
-        "fast-check": "^3.15.1"
+        "fast-check": "^3.14.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@waku/sdk": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.23.tgz",
-      "integrity": "sha512-uYXbTpzfyghOvQrNGmiLQHFbubv84LKwqJHJgZXIvSHv4GcMInV5BBE+HEumtSqlMwSP7MYxLJ559w6Rct83zQ==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.22.tgz",
+      "integrity": "sha512-4ZnoYcnfuFYKtA738R6X/9RAoPM/cvG7PvkFp9y7wrnjKFBfb5/Ha36k20AkvdTAmdoUXmdl5g4i9q0iUapeBg==",
       "peer": true,
       "dependencies": {
-        "@chainsafe/libp2p-noise": "^14.1.0",
-        "@libp2p/bootstrap": "^10.0.11",
-        "@libp2p/identify": "^1.0.11",
-        "@libp2p/mplex": "^10.0.12",
-        "@libp2p/ping": "^1.0.11",
-        "@libp2p/websockets": "^8.0.11",
-        "@waku/core": "0.0.27",
-        "@waku/dns-discovery": "0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/local-peer-cache-discovery": "^1.0.0",
-        "@waku/peer-exchange": "^0.0.20",
-        "@waku/relay": "0.0.10",
-        "@waku/utils": "0.0.15",
-        "libp2p": "^1.1.2"
+        "@chainsafe/libp2p-noise": "^13.0.4",
+        "@libp2p/mplex": "^9.0.10",
+        "@libp2p/websockets": "^7.0.5",
+        "@waku/core": "0.0.26",
+        "@waku/dns-discovery": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/peer-exchange": "^0.0.19",
+        "@waku/relay": "0.0.9",
+        "@waku/utils": "0.0.14",
+        "libp2p": "^0.46.14"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "@libp2p/bootstrap": "^10"
       }
     },
     "node_modules/@waku/utils": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.15.tgz",
-      "integrity": "sha512-zwRQcr3ECMM395umh0s17wMXkrjtcHW5xIw7CMOi/xsqV5ZAZi7P/SSMo2trngAsTxSJPDgeF60ChiwnsrsFbw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.14.tgz",
+      "integrity": "sha512-BbrmT2ryL6ws+VXiihzL4IR9Yi8dH5JD6yTqkX14ilMu7DhiGqCGuyu2EQsng9x1/Bn1ulU60NQh3tFzENKAFQ==",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.22",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^4.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -3164,6 +3192,20 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
+    },
+    "node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "peer": true,
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -3432,20 +3474,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "peer": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3590,6 +3618,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3943,7 +3981,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4004,9 +4041,9 @@
       }
     },
     "node_modules/datastore-core": {
-      "version": "9.2.9",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.9.tgz",
-      "integrity": "sha512-wraWTPsbtdE7FFaVo3pwPuTB/zXsgwGGAm8BgBYwYAuzZCTS0MfXmd/HH1vR9s0/NFFjOVmBkGiWCvKxZ+QjVw==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.8.tgz",
+      "integrity": "sha512-+S3rI6FSQphrGQZraYcCLeaVzCpDkNBYBk9a8QU8Kt+7xPAphNVA6a37kc6K9CQBppVOOmRaPBKU19fhHJLszg==",
       "peer": true,
       "dependencies": {
         "@libp2p/logger": "^4.0.6",
@@ -4022,6 +4059,39 @@
         "it-sort": "^3.0.4",
         "it-take": "^3.0.4"
       }
+    },
+    "node_modules/datastore-core/node_modules/@libp2p/interface": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+      "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+      "peer": true,
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/datastore-core/node_modules/@libp2p/logger": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.6.tgz",
+      "integrity": "sha512-ofTE3kDivBJnUSoX68nOeg1EuAnIE8oUjUnQnuKrxH+nh0JtjTcvwwIzjmm4nApwb4xj2dgPSDvU38Mjmu3TvA==",
+      "peer": true,
+      "dependencies": {
+        "@libp2p/interface": "^1.1.3",
+        "@multiformats/multiaddr": "^12.1.14",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.10",
+        "multiformats": "^13.0.1"
+      }
+    },
+    "node_modules/datastore-core/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4093,6 +4163,128 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "peer": true,
+      "dependencies": {
+        "execa": "^7.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/default-gateway/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-gateway/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "peer": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-gateway/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -4429,19 +4621,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
+      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/eslintrc": "^2.1.1",
+        "@eslint/js": "^8.46.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -4449,7 +4640,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
+        "eslint-visitor-keys": "^3.4.2",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -4587,10 +4778,32 @@
         "eslint": ">=5.0.0"
       }
     },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4755,9 +4968,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.16.0.tgz",
-      "integrity": "sha512-k8GtQHi4pJoRQ1gVDFQno+/FVkowo/ehiz/aCj9O/D7HRWb1sSFzNrw+iPVU8QlWtH+jNwbuN+dDVg3QkS56DQ==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
       "funding": [
         {
           "type": "individual",
@@ -4789,9 +5002,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5024,6 +5237,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5152,7 +5375,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5229,9 +5451,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -5579,10 +5801,25 @@
         "uint8arrays": "^5.0.2"
       }
     },
+    "node_modules/interface-datastore/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/interface-store": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
-      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ==",
       "peer": true
     },
     "node_modules/internal-slot": {
@@ -5597,6 +5834,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5747,6 +6005,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.0.1.tgz",
+      "integrity": "sha512-OwQXkwBJeESyhFw+OumbJVD58BFBJJI5OM5S1+eyrDKlgDZPX2XNT5gXS56GSD3NPbbwUuMlR1Q71SRp5SobuQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -5912,8 +6182,16 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -5996,6 +6274,16 @@
       "integrity": "sha512-UMiy0i9DqCHBdWvMbzdYvVGa5/w4t1cc4nchpbnjdLhklglv8mQeEYnii0gvKESJuL1zV32Cqdb33R6/GPfxpQ==",
       "peer": true
     },
+    "node_modules/it-batched-bytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-2.0.5.tgz",
+      "integrity": "sha512-2VgeZ+7KPef0SD2ZgkZfWFe+sgZKdxkzNZXbsYG44nGe4NzWSZLJ6lUjkKHW/S5pSKyW88uacosz6B6K++1LDA==",
+      "peer": true,
+      "dependencies": {
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
+    },
     "node_modules/it-byte-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.0.8.tgz",
@@ -6029,6 +6317,23 @@
       "integrity": "sha512-FtQl84iTNxN5EItP/JgL28V2rzNMkCzTUlNoj41eVdfix2z1DBuLnBqZ0hzYhGGa1rMpbQf0M7CQSA2adlrLJg==",
       "peer": true
     },
+    "node_modules/it-handshake": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
+      "peer": true,
+      "dependencies": {
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-length-prefixed": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.4.tgz",
@@ -6057,6 +6362,21 @@
         "it-stream-types": "^2.0.1",
         "uint8-varint": "^2.0.1",
         "uint8arraylist": "^2.4.1"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/it-length-prefixed/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/it-map": {
@@ -6182,15 +6502,16 @@
       "peer": true
     },
     "node_modules/it-ws": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.1.tgz",
-      "integrity": "sha512-oyk4eCeZto2lzWDnJOa3j1S2M+VOGKUh8isEf94ySoaL6IFlyie0T4P9E0ZUaIvX8LyJxYFHFKCt8Zk7Sm/XPQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.0.5.tgz",
+      "integrity": "sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==",
       "peer": true,
       "dependencies": {
         "@types/ws": "^8.2.2",
         "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
         "it-stream-types": "^2.0.1",
-        "uint8arrays": "^5.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       },
       "engines": {
@@ -7558,46 +7879,56 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-1.2.4.tgz",
-      "integrity": "sha512-K3Hc4Ty0zTS0+CHgM7w1d66kDV6GHJnSlZWkSBEQdnpQ+TiEdRDeT0+Ie3bIaAQlSzEWVuqda5mW4dzl1V6EcQ==",
+      "version": "0.46.21",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.46.21.tgz",
+      "integrity": "sha512-p/3vCpw+ciizhlBofpzuez+4Fs8EeVFaVQZUQPwnQwycuOFcWLBhcqkOtv4KlqImFKOk+9TuyW1Xofjmr/wPnA==",
       "peer": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/logger": "^4.0.7",
-        "@libp2p/multistream-select": "^5.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-id-factory": "^4.0.7",
-        "@libp2p/peer-store": "^10.0.11",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@achingbrain/nat-port-mapper": "^1.0.9",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/interface-internal": "^0.1.9",
+        "@libp2p/keychain": "^3.0.8",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/multistream-select": "^4.0.6",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/peer-id-factory": "^3.0.8",
+        "@libp2p/peer-record": "^6.0.9",
+        "@libp2p/peer-store": "^9.0.9",
+        "@libp2p/utils": "^4.0.7",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-matcher": "^1.0.0",
         "any-signal": "^4.1.1",
-        "datastore-core": "^9.2.8",
-        "interface-datastore": "^8.2.11",
-        "it-merge": "^3.0.3",
-        "it-parallel": "^3.0.6",
+        "datastore-core": "^9.0.1",
+        "delay": "^6.0.0",
+        "interface-datastore": "^8.2.0",
+        "it-all": "^3.0.2",
+        "it-drain": "^3.0.2",
+        "it-filter": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-map": "^3.0.3",
+        "it-merge": "^3.0.0",
+        "it-pair": "^2.0.6",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-protobuf-stream": "^1.0.0",
+        "it-stream-types": "^2.0.1",
         "merge-options": "^3.0.4",
-        "multiformats": "^13.1.0",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/crypto": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-      "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-      "peer": true,
-      "dependencies": {
-        "@libp2p/interface": "^1.1.4",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "p-retry": "^6.0.0",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^5.0.0",
+        "rate-limiter-flexible": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6",
+        "wherearewe": "^2.0.1",
+        "xsalsa20": "^1.1.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7624,14 +7955,19 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7713,8 +8049,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7809,21 +8144,47 @@
         "p-timeout": "^6.0.0"
       }
     },
+    "node_modules/mortice/node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
-      "peer": true
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/netmask": {
@@ -8091,9 +8452,9 @@
       }
     },
     "node_modules/p-event": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
-      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
       "peer": true,
       "dependencies": {
         "p-timeout": "^6.1.2"
@@ -8136,16 +8497,45 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
       "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "p-timeout": "^5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8236,7 +8626,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8390,6 +8779,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "peer": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8452,6 +8847,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/private-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.1.tgz",
+      "integrity": "sha512-Ezc16ANuhSHmWAE6lbXUKburNzGpR0J5X0Zh5Um/PZ/s57Fp+HYqYe6BYPH2QbqKr/5WebfzJQ1jq6Kj5dbRmA==",
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.1.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/progress-events": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
@@ -8492,6 +8902,30 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/protons-runtime": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
@@ -8501,6 +8935,21 @@
         "uint8-varint": "^2.0.2",
         "uint8arraylist": "^2.4.3",
         "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/psl": {
@@ -8533,24 +8982,6 @@
         }
       ]
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -8577,16 +9008,10 @@
         }
       ]
     },
-    "node_modules/race-event": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.2.0.tgz",
-      "integrity": "sha512-7EvAjTu9uuKa03Jky8yfSy6/SnnMTh6nouNmdeWv9b0dT8eDZC5ylx30cOR9YO9otQorVjjkIuSHQ5Ml/bKwMw==",
-      "peer": true
-    },
     "node_modules/race-signal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.2.tgz",
-      "integrity": "sha512-o3xNv0iTcIDQCXFlF6fPAMEBRjFxssgGoRqLbg06m+AdzEXXLUmoNOoUHTVz2NoBI8hHwKFKoC6IqyNtWr2bww==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
+      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw==",
       "peer": true
     },
     "node_modules/randombytes": {
@@ -8597,6 +9022,12 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-3.0.6.tgz",
+      "integrity": "sha512-tlvbee6lyse/XTWmsuBDS4MT8N65FyM151bPmQlFyfhv9+RIHs7d3rSTXoz0j35H910dM01mH0yTIeWYo8+aAw==",
+      "peer": true
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -8832,6 +9263,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -9121,6 +9561,21 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "peer": true,
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "peer": true
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9179,7 +9634,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -9191,7 +9645,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9213,8 +9666,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -9626,22 +10078,41 @@
         "node": ">=12"
       }
     },
-    "node_modules/ts-api-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "peer": true,
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "dev": true
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9763,6 +10234,21 @@
         "uint8arrays": "^5.0.0"
       }
     },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/uint8arraylist": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
@@ -9772,13 +10258,28 @@
         "uint8arrays": "^5.0.1"
       }
     },
-    "node_modules/uint8arrays": {
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "peer": true
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
       "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
       "peer": true,
       "dependencies": {
         "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
+      "peer": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9853,6 +10354,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
+      "peer": true
     },
     "node_modules/utf8-bytes": {
       "version": "0.0.1",
@@ -10002,7 +10509,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -10085,9 +10591,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10113,11 +10619,39 @@
         "node": ">=12"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "peer": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==",
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -10180,6 +10714,69 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@achingbrain/nat-port-mapper": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.13.tgz",
+      "integrity": "sha512-B5GL6ILDek72OjoEyFGEuuNYaEOYxO06Ulhcaf/5iQ4EO8uaZWS+OkolYST7L+ecJrkjfaSNmSAsWRRuh+1Z5A==",
+      "peer": true,
+      "requires": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^4.0.1",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      },
+      "dependencies": {
+        "@libp2p/interface": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+          "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+          "peer": true,
+          "requires": {
+            "@multiformats/multiaddr": "^12.1.14",
+            "it-pushable": "^3.2.3",
+            "it-stream-types": "^2.0.1",
+            "multiformats": "^13.0.1",
+            "progress-events": "^1.0.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "@libp2p/logger": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.6.tgz",
+          "integrity": "sha512-ofTE3kDivBJnUSoX68nOeg1EuAnIE8oUjUnQnuKrxH+nh0JtjTcvwwIzjmm4nApwb4xj2dgPSDvU38Mjmu3TvA==",
+          "peer": true,
+          "requires": {
+            "@libp2p/interface": "^1.1.3",
+            "@multiformats/multiaddr": "^12.1.14",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.10",
+            "multiformats": "^13.0.1"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        }
+      }
+    },
+    "@achingbrain/ssdp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.6.tgz",
+      "integrity": "sha512-Y4JE2L9150i50V6lg/Y8+ilhxRpUZKKv+PKo68Aj7MjPfaUAar6ZHilF9h4/Zb3q0fqGMXNc9o11cQLNI8J8bA==",
+      "peer": true,
+      "requires": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.6.2"
+      }
     },
     "@adobe/css-tools": {
       "version": "4.2.0",
@@ -10724,56 +11321,41 @@
       "peer": true
     },
     "@chainsafe/libp2p-gossipsub": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-12.0.0.tgz",
-      "integrity": "sha512-ZuVIvzZjUaZXSPG6Ni9veVBLkZ4OkVp3zc3E8Y5EG/iIUSNVbHLFxweb3HuA12e3lIXLLurvy4vDyGWp4FpKow==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-10.1.1.tgz",
+      "integrity": "sha512-nou65zlGaUIPwlUq7ceEVpszJX4tBWRRanppYaKsJk7rbDeIKRJQla2duATGOI3fwj1+pGSlDQuF2zG7P0VJQw==",
       "peer": true,
       "requires": {
-        "@libp2p/crypto": "^4.0.1",
-        "@libp2p/interface": "^1.1.2",
-        "@libp2p/interface-internal": "^1.0.7",
-        "@libp2p/peer-id": "^4.0.5",
-        "@libp2p/pubsub": "^9.0.8",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/crypto": "^2.0.0",
+        "@libp2p/interface": "^0.1.4",
+        "@libp2p/interface-internal": "^0.1.0",
+        "@libp2p/logger": "^3.0.0",
+        "@libp2p/peer-id": "^3.0.0",
+        "@libp2p/pubsub": "^8.0.0",
+        "@multiformats/multiaddr": "^12.1.3",
+        "abortable-iterator": "^5.0.1",
         "denque": "^2.1.0",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "multiformats": "^13.0.1",
-        "protons-runtime": "5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "it-pushable": "^3.2.0",
+        "multiformats": "^12.0.1",
+        "protobufjs": "^7.2.4",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.4"
       }
     },
     "@chainsafe/libp2p-noise": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-14.1.0.tgz",
-      "integrity": "sha512-uHmptoxgMsfDIP7cQMQ4Zp9+y27oON5+gloBLXi+7EJpMhyvo7tjafUxRILwLofzeAtfaF3ZHraoXRFUSbhK2Q==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-13.0.5.tgz",
+      "integrity": "sha512-xXqwrkH4nXlv3cYENHtqOgmIT2M4irPDwi548UvpmxzeC9hqa0kmiqbtAFYMV3v+gJ9pqVBVWFRk2hjs83GNrw==",
       "peer": true,
       "requires": {
         "@chainsafe/as-chacha20poly1305": "^0.1.0",
         "@chainsafe/as-sha256": "^0.4.1",
-        "@libp2p/crypto": "^3.0.0",
-        "@libp2p/interface": "^1.0.0",
-        "@libp2p/peer-id": "^4.0.0",
+        "@libp2p/crypto": "^2.0.0",
+        "@libp2p/interface": "^0.1.0",
+        "@libp2p/logger": "^3.0.0",
+        "@libp2p/peer-id": "^3.0.0",
         "@noble/ciphers": "^0.4.0",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
@@ -10785,7 +11367,7 @@
         "it-stream-types": "^2.0.1",
         "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0",
+        "uint8arrays": "^4.0.4",
         "wherearewe": "^2.0.1"
       }
     },
@@ -10814,9 +11396,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -10831,9 +11413,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
+      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
       "dev": true
     },
     "@ethersproject/bytes": {
@@ -10862,13 +11444,13 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "requires": {
-        "@humanwhocodes/object-schema": "^2.0.2",
-        "debug": "^4.3.1",
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
         "minimatch": "^3.0.5"
       }
     },
@@ -10879,9 +11461,9 @@
       "dev": true
     },
     "@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -11507,77 +12089,48 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "peer": true
     },
-    "@libp2p/bootstrap": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-10.0.16.tgz",
-      "integrity": "sha512-ZFuq5OtQfdeZVjfWrJpW/OuPVOuAflu1nzq9g6/UiVfSvBaZtwe8hcMCQDXv21V8fCVsd703sblzkBwBYi17rQ==",
-      "peer": true,
-      "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.14"
-      }
-    },
     "@libp2p/crypto": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-3.0.4.tgz",
-      "integrity": "sha512-FzSwBo+RJOUzdzEwug5ZL4dAGKwEBWTLzj+EmUTHHY6c87+oLh571DQk/w0oYObSD9hYbcKePgSBaZeBx0JaZg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.8.tgz",
+      "integrity": "sha512-8e5fh6bsJNpSjhrggtlm8QF+BERjelJswIjRS69aKgxp24R4z2kDM4pRYPkfQjXJDLNDtqWtKNmePgX23+QJsA==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.1",
+        "@libp2p/interface": "^0.1.6",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
-        "multiformats": "^13.0.0",
+        "multiformats": "^12.0.1",
         "node-forge": "^1.1.0",
         "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "@libp2p/identify": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-1.0.15.tgz",
-      "integrity": "sha512-Pve7UJKbEqN6nMpc2yjUiNvjpVwewixL3iX/bvhHQi9P4/x9zJkDIgncbdSUAXT0VePkJRRqvFJOye9Pdw4zRQ==",
-      "peer": true,
-      "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-record": "^7.0.10",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-matcher": "^1.1.2",
-        "it-protobuf-stream": "^1.1.2",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2",
-        "wherearewe": "^2.0.1"
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/interface": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.4.tgz",
-      "integrity": "sha512-gJXQycTF50tI02X/IlReAav4XoGPs3Yr917vNXsTUsZQRzQaPjbvKfXqA5hkLFpZ1lnxQ8wto/EVw4ca4XaL1A==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.6.tgz",
+      "integrity": "sha512-Lzc5cS/hXuoXhuAbVIxJIHLCYmfPcbU0vVgrpMoiP1Qb2Q3ETU4A46GB8s8mWXgSU6tr9RcqerUqzFYD6+OAag==",
       "peer": true,
       "requires": {
-        "@multiformats/multiaddr": "^12.1.14",
-        "it-pushable": "^3.2.3",
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
         "it-stream-types": "^2.0.1",
-        "multiformats": "^13.1.0",
-        "progress-events": "^1.0.0",
-        "uint8arraylist": "^2.4.8"
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "@libp2p/interface-internal": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.0.9.tgz",
-      "integrity": "sha512-c5BzjXdRnuI+xjLiPjGMxh6QbU51wEIdz/OrgQqo2dKDjWz3Qu0due9H2wzzB8nvSNWTLHRr1ucVga3SrmbngQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-0.1.12.tgz",
+      "integrity": "sha512-tUZ4hxU8fO4397p/GtXNvAANHiLA/Uxdil90TuNNCnlb+GZijDYEEJiqBfnk2zYAdwm7Q9iO0fVxZCpfoW8B7Q==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@multiformats/multiaddr": "^12.1.14",
-        "uint8arraylist": "^2.4.8"
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@multiformats/multiaddr": "^12.1.5",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "@libp2p/interfaces": {
@@ -11586,271 +12139,208 @@
       "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
       "peer": true
     },
-    "@libp2p/logger": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.7.tgz",
-      "integrity": "sha512-oyICns7G18S4eDhbFHUwZ7gLQnZTBVQtUMmMgEmrs8LnQu2GvXADxmQAPPkKtLNSCvRudg4hN3hP04Y+vNvlBQ==",
+    "@libp2p/keychain": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-3.0.8.tgz",
+      "integrity": "sha512-+WmW9bN9WE0uKqTG3DVk+zsd9Np63lLS+uYRhncwCGTvg0HKXq1t+i4Xd8KbZvUv7UVakE8aae1oMezW3nS+2g==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-id": "^3.0.6",
+        "interface-datastore": "^8.2.0",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "@libp2p/logger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.1.0.tgz",
+      "integrity": "sha512-qJbJBAhxHVsRBtQSOIkSLi0lskUSFjzE+zm0QvoyxzZKSz+mX41mZLbnofPIVOVauoDQ40dXpe7WDUOq8AbiQQ==",
+      "peer": true,
+      "requires": {
+        "@libp2p/interface": "^0.1.6",
+        "@multiformats/multiaddr": "^12.1.5",
         "debug": "^4.3.4",
-        "interface-datastore": "^8.2.11",
-        "multiformats": "^13.1.0"
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
       }
     },
     "@libp2p/mplex": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-10.0.16.tgz",
-      "integrity": "sha512-F5H322kVCkPoM0FKalmyo5HwVQ/c5vKNpw2uLLyr26bqy7/GQMNkKvs88Rv7O2s2OHe7txC9Uwo9mapF/j4LlQ==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-9.0.12.tgz",
+      "integrity": "sha512-ll+fsz9zJ9OW3Z14hN4uh5JDQWIfudp2HTsSKoBiiFnKNY58tMH01iijNtHXGyGiVPmFCPeJf01oPlx0j9OgDQ==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/utils": "^5.2.6",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "abortable-iterator": "^5.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^2.0.2",
+        "it-pushable": "^3.2.0",
         "it-stream-types": "^2.0.1",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "rate-limiter-flexible": "^3.0.0",
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/multistream-select": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-5.1.4.tgz",
-      "integrity": "sha512-hFK831x8SRQwWO6sZ0PLdLMJdxSw/HFWTZLqwFGsQbgfgBd+Via3Fztb7xe6VRqHpnAwZkVujP+iubAI7AghGg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-4.0.10.tgz",
+      "integrity": "sha512-f0BDv96L2yF9SZ0YXdg41JcGWwPBGZNAoeFGkna38SMFtj00NQWBOwAjqVdhrYVF58ymB0Ci6OfMzYv1XHVj/A==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "it-length-prefixed": "^9.0.4",
-        "it-length-prefixed-stream": "^1.1.6",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "abortable-iterator": "^5.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^2.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.2",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/peer-collections": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.1.7.tgz",
-      "integrity": "sha512-9XXWSJtC7XvbH32h2bK3fygyzd4B2/JeWzsjX8cUDtO69jKNiVJglB8UqajZBuwLZSOQG5aRNWK4RWXJDrsh/w==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-4.0.11.tgz",
+      "integrity": "sha512-4bHtIm3VfYMm2laRuebkswQukgQmWTUbExnu1sD5vcbI186aCZ7P56QjWyOIMn3XflIoZ0cx9AXX/WuDQSolDA==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7"
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6"
       }
     },
     "@libp2p/peer-id": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.7.tgz",
-      "integrity": "sha512-kbslH0VBmcHO1Osr/qQlFljPOYuldUC6OdYM5c6Tdy+KFU/W4P9Ouv/4e7o3uX6LtlQ8QqIsZH+/bR6AJxC8Gw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.6.tgz",
+      "integrity": "sha512-iN1Ia5gH2U1V/GOVRmLHmVY6fblxzrOPUoZrMYjHl/K4s+AiI7ym/527WDeQvhQpD7j3TfDwcAYforD2dLGpLw==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "multiformats": "^13.1.0",
-        "uint8arrays": "^5.0.2"
+        "@libp2p/interface": "^0.1.6",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/peer-id-factory": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.0.7.tgz",
-      "integrity": "sha512-ueSjkodKPhYw7C0ysRGscY+e9vJ+ixpmJvi5w8vbnOn0ex9cAT+9S7DGL03d8vGMAT3xjEbUsI2GpF17uZ9Rpg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-3.0.11.tgz",
+      "integrity": "sha512-BmXKgeyAGezPyoY/uni95t439+AE0eqEKMxjfkfy2Hv/LcJ9gdR3zjRl7Hzci1O12b+yeVFtYVU8DZtBCcsZjQ==",
       "peer": true,
       "requires": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/peer-record": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-7.0.10.tgz",
-      "integrity": "sha512-njVSa2mMcGqQoCnhmZQOadHIQMsO52wqKO6fP1On8sVRmb9yXNGBkZ+b5pRXjjPzUpJeUmC+/SZHpeLqpdpPMQ==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-6.0.12.tgz",
+      "integrity": "sha512-8IItsbcPeIaFC5QMZD+gGl/dDbwLjE9nrmL7ZAOvMwcfZx+2AVZPN/6nubahO/wQrchpvBYiK3TxaWGnOH8sIA==",
       "peer": true,
       "requires": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/multiaddr": "^12.1.14",
-        "protons-runtime": "^5.4.0",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/utils": "^4.0.7",
+        "@multiformats/multiaddr": "^12.1.5",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^2.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/peer-store": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-10.0.11.tgz",
-      "integrity": "sha512-egcEzHRQUTW7mQuLPyN/y0Rtunk8zFoxLdTRNjJTrvQRmkCeLIDZ8VsYB0KF7feA85nbpRFR62dVjN46I65yFA==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-9.0.12.tgz",
+      "integrity": "sha512-rYpUUhvDI7GTfMFWNJ+HQoEOAVOxfp3t0bgJWLvUFKNtULojEk0znKHa6da7hX2KE06wM7ZEMfF23jZCmrwk1g==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-record": "^7.0.10",
-        "@multiformats/multiaddr": "^12.1.14",
-        "interface-datastore": "^8.2.11",
-        "it-all": "^3.0.4",
-        "mortice": "^3.0.4",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "@libp2p/ping": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-1.0.12.tgz",
-      "integrity": "sha512-xJjJJO/2HUBLHMNHjgLpGQdYJHDQeLcIqflBIerpoRKNuc8omusTQ2PRrvMZzvK+N7fZYk7tOuBNZ8wWxVSX6w==",
-      "peer": true,
-      "requires": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@multiformats/multiaddr": "^12.1.14",
-        "it-first": "^3.0.4",
-        "it-pipe": "^3.0.1",
-        "uint8arrays": "^5.0.2"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/peer-id-factory": "^3.0.8",
+        "@libp2p/peer-record": "^6.0.9",
+        "@multiformats/multiaddr": "^12.1.5",
+        "interface-datastore": "^8.2.0",
+        "it-all": "^3.0.2",
+        "mortice": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/pubsub": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.11.tgz",
-      "integrity": "sha512-LqGjLHF+8owS9Yxlzpuo6sdY2pe5WMVnKePMNzyT05w1xbmLi21GHF2H5t64zQoxG30vOUGiGwKOB32e4UWaHg==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-8.0.14.tgz",
+      "integrity": "sha512-hkNqUC6ef96WxqYFnmG0CKy9Vvb0mum5IrllUypwWiV0iK1zj8PcqO8oyTjLl/waLG56Kuy8CAjahnMov+U3dw==",
       "peer": true,
       "requires": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/utils": "^5.2.6",
-        "it-length-prefixed": "^9.0.4",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/interface-internal": "^0.1.9",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "abortable-iterator": "^5.0.1",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "multiformats": "^13.1.0",
-        "p-queue": "^8.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.2"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "it-pushable": "^3.2.0",
+        "multiformats": "^12.0.1",
+        "p-queue": "^7.3.4",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
       }
     },
     "@libp2p/utils": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.2.6.tgz",
-      "integrity": "sha512-2Y2zi2TsyhOl+8TH27YZiEJWfdrKRogTzYRxQUKNTX03izXpUcwGsFLPjK7nR39LzYQrQ8si1Kx2ayA3zk7BKg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-4.0.7.tgz",
+      "integrity": "sha512-xA6mS4II14870/DmmI3GFRWdNwHeOd2QV3ltatpdVmeEQpdn82jjtCzqn45AChjCugFOskOthXnQiWp+FvdKZg==",
       "peer": true,
       "requires": {
         "@chainsafe/is-ip": "^2.0.2",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/logger": "^4.0.7",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-matcher": "^1.1.2",
-        "delay": "^6.0.0",
-        "get-iterator": "^2.0.1",
-        "is-loopback-addr": "^2.0.2",
-        "it-pushable": "^3.2.3",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/logger": "^3.1.0",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-matcher": "^1.0.1",
+        "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^2.0.1",
-        "netmask": "^2.0.2",
-        "p-defer": "^4.0.0",
-        "race-event": "^1.2.0",
-        "race-signal": "^1.0.2",
-        "uint8arraylist": "^2.4.8"
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "@libp2p/websockets": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-8.0.16.tgz",
-      "integrity": "sha512-8SNuGCDtjzObIAr05mXaY7kB1Bz85Tda3T3byHpUVvn7IPbkdkGe0NiKB+ZvK7ZJhBL/7FdQZmVp3GBffWWrmg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-7.0.6.tgz",
+      "integrity": "sha512-Hoe6KJMCKkLv00xWtCCZcdcoRX5GoR0ebdsc+PlMPPpPNhkbTa1OH1I8bcLU6VBMaaWLWuTyIZE6rWTu/+k/9g==",
       "peer": true,
       "requires": {
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-to-uri": "^10.0.1",
-        "@types/ws": "^8.5.10",
-        "it-ws": "^6.1.1",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/logger": "^3.0.2",
+        "@libp2p/utils": "^4.0.3",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "@types/ws": "^8.5.4",
+        "abortable-iterator": "^5.0.1",
+        "it-ws": "^6.0.0",
         "p-defer": "^4.0.0",
         "wherearewe": "^2.0.1",
-        "ws": "^8.16.0"
+        "ws": "^8.12.1"
       }
     },
     "@multiformats/mafmt": {
@@ -11875,23 +12365,54 @@
         "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
         "uint8arrays": "^5.0.0"
+      },
+      "dependencies": {
+        "@libp2p/interface": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+          "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+          "peer": true,
+          "requires": {
+            "@multiformats/multiaddr": "^12.1.14",
+            "it-pushable": "^3.2.3",
+            "it-stream-types": "^2.0.1",
+            "multiformats": "^13.0.1",
+            "progress-events": "^1.0.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "@multiformats/multiaddr-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.1.2.tgz",
-      "integrity": "sha512-O7hO+TYsweMjNCqTYKYn8iki2GXA46mxmgqnsOb2Wpr6ca4dRGnPldWTai2WwTeZpQyRJ/7GE+N9zPTfP0xE+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.0.1.tgz",
+      "integrity": "sha512-ZzqwTH8tP5Py/k8eNKprO0i6tuwgrbp7KWz+ttxvzkPl43BlU9Yd5joq+M5grCt158rpAc2uhPobzfXgPxW5XQ==",
       "peer": true,
       "requires": {
         "@chainsafe/is-ip": "^2.0.1",
         "@multiformats/multiaddr": "^12.0.0",
-        "multiformats": "^13.0.0"
+        "multiformats": "^12.0.1"
       }
     },
     "@multiformats/multiaddr-to-uri": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.0.1.tgz",
-      "integrity": "sha512-RtOBRJucMCzINPytvt1y7tJ2jr4aSKJmv3DF7/C515RJO9+nu9sZHdsk9vn251OtN8k21rAGlIHESt/BSJWAnQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
+      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
       "peer": true,
       "requires": {
         "@multiformats/multiaddr": "^12.0.0"
@@ -11949,6 +12470,70 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "peer": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "peer": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "peer": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "peer": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "peer": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "peer": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "peer": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "peer": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "peer": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "peer": true
     },
     "@rollup/plugin-commonjs": {
       "version": "24.1.0",
@@ -12245,9 +12830,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "@types/node": {
@@ -12278,6 +12863,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "peer": true
+    },
     "@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -12285,9 +12876,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -12312,9 +12903,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "peer": true,
       "requires": {
         "@types/node": "*"
@@ -12336,148 +12927,119 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.1.tgz",
-      "integrity": "sha512-zioDz623d0RHNhvx0eesUmGfIjzrk18nSBC8xewepKXbBvN/7c1qImV7Hg8TI1URTxKax7/zxfxj3Uph8Chcuw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "requires": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/type-utils": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
-        "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
-      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
-      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1"
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.1.tgz",
-      "integrity": "sha512-5r4RKze6XHEEhlZnJtR3GYeCh1IueUHdbrukV2KSlLXaTjuSfeVF8mZUVPLovidCuZfbVjfhi4c0DNSa/Rdg5g==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
-      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
-      "integrity": "sha512-thOXM89xA03xAE0lW7alstvnyoBUbBX38YtY+zAUcpRPcq9EIhXPuJ0YTv948MbzmKh6e1AUszn5cBFK49Umqg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "semver": "^7.5.4"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
-      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.1.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
-    },
     "@waku/core": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.27.tgz",
-      "integrity": "sha512-SPUiR0NrbfuHVhvU91Fnhkjnqkk76DBgYkTtjuLoJ7SbRJFYrnUqnSAXVwe2H+kDXq/M+UgUandLAPS6EyH+2A==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.26.tgz",
+      "integrity": "sha512-aarhaFrN/mDKB2tmVUSodMDt9V3CwllKFy8iYsy+fBcK1cBrv6Yj2nnl6PLDDhfxv+bylzS/OKEvEIAJ+be7YA==",
       "peer": true,
       "requires": {
-        "@libp2p/ping": "^1.0.11",
         "@noble/hashes": "^1.3.2",
-        "@waku/enr": "^0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/message-hash": "^0.1.11",
+        "@waku/enr": "^0.0.20",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1",
         "p-event": "^6.0.0",
         "uint8arraylist": "^2.4.3",
@@ -12485,95 +13047,103 @@
       }
     },
     "@waku/dns-discovery": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.21.tgz",
-      "integrity": "sha512-l6TVLNiP9HjVrSCWRVP4pKGAADkPzMY2+/tFxnLI1lx3NWmBrkwsEsZHKlfGpdDTT3130nxXkvENcswqWLsc1w==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.20.tgz",
+      "integrity": "sha512-JnzR/B3iT33aWDg75lGkzM+4eXqZP5n/BlnjMyiXCXX+Du4arRveBg+812ZXZVVMQGLiM/aqM/JOPefKbTegOw==",
       "peer": true,
       "requires": {
-        "@waku/enr": "0.0.21",
-        "@waku/utils": "0.0.15",
+        "@waku/enr": "0.0.20",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^4.0.4"
       }
     },
     "@waku/enr": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.21.tgz",
-      "integrity": "sha512-FnfA7I+MDH5mJF9thS/a/6dTRLO8WF4WRj1/4BisRr9xTxHBq/qqgzGrk5JAWbeX6Befjle3Bi6cYdbSXGvNQw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.20.tgz",
+      "integrity": "sha512-dzTeESBxagggAaJ6xMCEaiB1PdNN+rLFuLF3mC/0iSgb6Ax2nl5lJmSVTsZpdkPuwiv+sZzt5KgaKzjQEvp0QA==",
       "peer": true,
       "requires": {
         "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^4.0.0",
-        "@libp2p/peer-id": "^4.0.4",
+        "@libp2p/crypto": "^3.0.2",
+        "@libp2p/peer-id": "^3.0.3",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2"
       },
       "dependencies": {
         "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-3.0.4.tgz",
+          "integrity": "sha512-FzSwBo+RJOUzdzEwug5ZL4dAGKwEBWTLzj+EmUTHHY6c87+oLh571DQk/w0oYObSD9hYbcKePgSBaZeBx0JaZg==",
           "peer": true,
           "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
+            "@libp2p/interface": "^1.1.1",
+            "@noble/curves": "^1.1.0",
+            "@noble/hashes": "^1.3.1",
+            "multiformats": "^13.0.0",
+            "node-forge": "^1.1.0",
+            "protons-runtime": "^5.0.0",
+            "uint8arraylist": "^2.4.3",
+            "uint8arrays": "^5.0.0"
+          }
+        },
+        "@libp2p/interface": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+          "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+          "peer": true,
+          "requires": {
+            "@multiformats/multiaddr": "^12.1.14",
+            "it-pushable": "^3.2.3",
+            "it-stream-types": "^2.0.1",
+            "multiformats": "^13.0.1",
+            "progress-events": "^1.0.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
           }
         }
       }
     },
     "@waku/interfaces": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.22.tgz",
-      "integrity": "sha512-SbOCqqv4wLkvVMuIppBXzLjyRHw1rnW3lzeIlNJrTwjIQvhIwasUyHIbZ9Wk9hv1ybhx7HmRuWdesWDQn1x0hQ==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.21.tgz",
+      "integrity": "sha512-6QbXx9IEBz9muSzjrnbaoXnjrMQIu1WOUyhMB6ZgOobgGWluwX/WOPuGGCpqvI7p5WhO0gaziphGVLdopdmRyw==",
       "peer": true
     },
-    "@waku/local-peer-cache-discovery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@waku/local-peer-cache-discovery/-/local-peer-cache-discovery-1.0.0.tgz",
-      "integrity": "sha512-He3xudQF8cMbQUU2q9nUlinSW8FSwKX51DLwhPhblVVwhrfdmjvfhjCaMaq2YDoA+y88CIqQG0bLxxl5QADpWQ==",
-      "peer": true,
-      "requires": {
-        "@libp2p/interface": "^1.1.2",
-        "@waku/interfaces": "^0.0.22",
-        "@waku/utils": "^0.0.15"
-      }
-    },
-    "@waku/message-hash": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.11.tgz",
-      "integrity": "sha512-Z9OYVZtooVLCLr5BXZiCPnrgaucse9jvtlgAXRvV9xupfj24h6qMe94KLdefr8nED75nQuUwpHzaA6u+lXL2wg==",
-      "peer": true,
-      "requires": {
-        "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.15"
-      }
-    },
     "@waku/peer-exchange": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@waku/peer-exchange/-/peer-exchange-0.0.20.tgz",
-      "integrity": "sha512-Tbdw80VAk4Or6sKUX4LPCkuDo4zYB1/6hOLOMbSo1ck7w8ADNkcByyD5W/wVCmE4wM8Yen2Awb/auIsqunM8LQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@waku/peer-exchange/-/peer-exchange-0.0.19.tgz",
+      "integrity": "sha512-T6eGHidBj49Lkw0fy3gKXbdJiyQ/0b6WYp8ZgJUySmtFCMmFQUEECbdHLx5iJFtocYmbGYFt04f+47dhoCyhog==",
       "peer": true,
       "requires": {
         "@libp2p/interfaces": "^3.3.2",
-        "@waku/core": "0.0.27",
-        "@waku/enr": "0.0.21",
-        "@waku/interfaces": "0.0.22",
+        "@waku/core": "0.0.26",
+        "@waku/enr": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
-        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed": "^9.0.1",
         "it-pipe": "^3.0.1"
       }
     },
@@ -12587,55 +13157,51 @@
       }
     },
     "@waku/relay": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.10.tgz",
-      "integrity": "sha512-nrmaUdjRFksGnsY1PFFcKI0Qn7RRCWIP17zK9CObLLocC4MFvchcmw4zWJveATJE1sCxbG97jDWsiA4SZJpGNA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.9.tgz",
+      "integrity": "sha512-BfjPUVh4rIyZ82PPGBhCIv7nnx/WhrqkpkcXmmM38gsRDHDZSNCE28I3ILs2m+IBjBdeaT16BCq0dUVQD84m2A==",
       "peer": true,
       "requires": {
-        "@chainsafe/libp2p-gossipsub": "^12.0.0",
+        "@chainsafe/libp2p-gossipsub": "^10.1.1",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.27",
-        "@waku/interfaces": "0.0.22",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
         "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
-        "fast-check": "^3.15.1"
+        "fast-check": "^3.14.0"
       }
     },
     "@waku/sdk": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.23.tgz",
-      "integrity": "sha512-uYXbTpzfyghOvQrNGmiLQHFbubv84LKwqJHJgZXIvSHv4GcMInV5BBE+HEumtSqlMwSP7MYxLJ559w6Rct83zQ==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.22.tgz",
+      "integrity": "sha512-4ZnoYcnfuFYKtA738R6X/9RAoPM/cvG7PvkFp9y7wrnjKFBfb5/Ha36k20AkvdTAmdoUXmdl5g4i9q0iUapeBg==",
       "peer": true,
       "requires": {
-        "@chainsafe/libp2p-noise": "^14.1.0",
-        "@libp2p/bootstrap": "^10.0.11",
-        "@libp2p/identify": "^1.0.11",
-        "@libp2p/mplex": "^10.0.12",
-        "@libp2p/ping": "^1.0.11",
-        "@libp2p/websockets": "^8.0.11",
-        "@waku/core": "0.0.27",
-        "@waku/dns-discovery": "0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/local-peer-cache-discovery": "^1.0.0",
-        "@waku/peer-exchange": "^0.0.20",
-        "@waku/relay": "0.0.10",
-        "@waku/utils": "0.0.15",
-        "libp2p": "^1.1.2"
+        "@chainsafe/libp2p-noise": "^13.0.4",
+        "@libp2p/mplex": "^9.0.10",
+        "@libp2p/websockets": "^7.0.5",
+        "@waku/core": "0.0.26",
+        "@waku/dns-discovery": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/peer-exchange": "^0.0.19",
+        "@waku/relay": "0.0.9",
+        "@waku/utils": "0.0.14",
+        "libp2p": "^0.46.14"
       }
     },
     "@waku/utils": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.15.tgz",
-      "integrity": "sha512-zwRQcr3ECMM395umh0s17wMXkrjtcHW5xIw7CMOi/xsqV5ZAZi7P/SSMo2trngAsTxSJPDgeF60ChiwnsrsFbw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.14.tgz",
+      "integrity": "sha512-BbrmT2ryL6ws+VXiihzL4IR9Yi8dH5JD6yTqkX14ilMu7DhiGqCGuyu2EQsng9x1/Bn1ulU60NQh3tFzENKAFQ==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.22",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^4.0.4"
       }
     },
     "abab": {
@@ -12643,6 +13209,16 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
+    },
+    "abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "peer": true,
+      "requires": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      }
     },
     "acorn": {
       "version": "8.10.0",
@@ -12837,17 +13413,6 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
-    "asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "peer": true,
-      "requires": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      }
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -12956,6 +13521,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "peer": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -13210,7 +13785,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -13264,9 +13838,9 @@
       }
     },
     "datastore-core": {
-      "version": "9.2.9",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.9.tgz",
-      "integrity": "sha512-wraWTPsbtdE7FFaVo3pwPuTB/zXsgwGGAm8BgBYwYAuzZCTS0MfXmd/HH1vR9s0/NFFjOVmBkGiWCvKxZ+QjVw==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.8.tgz",
+      "integrity": "sha512-+S3rI6FSQphrGQZraYcCLeaVzCpDkNBYBk9a8QU8Kt+7xPAphNVA6a37kc6K9CQBppVOOmRaPBKU19fhHJLszg==",
       "peer": true,
       "requires": {
         "@libp2p/logger": "^4.0.6",
@@ -13281,6 +13855,41 @@
         "it-pushable": "^3.2.3",
         "it-sort": "^3.0.4",
         "it-take": "^3.0.4"
+      },
+      "dependencies": {
+        "@libp2p/interface": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
+          "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+          "peer": true,
+          "requires": {
+            "@multiformats/multiaddr": "^12.1.14",
+            "it-pushable": "^3.2.3",
+            "it-stream-types": "^2.0.1",
+            "multiformats": "^13.0.1",
+            "progress-events": "^1.0.0",
+            "uint8arraylist": "^2.4.8"
+          }
+        },
+        "@libp2p/logger": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.6.tgz",
+          "integrity": "sha512-ofTE3kDivBJnUSoX68nOeg1EuAnIE8oUjUnQnuKrxH+nh0JtjTcvwwIzjmm4nApwb4xj2dgPSDvU38Mjmu3TvA==",
+          "peer": true,
+          "requires": {
+            "@libp2p/interface": "^1.1.3",
+            "@multiformats/multiaddr": "^12.1.14",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.10",
+            "multiformats": "^13.0.1"
+          }
+        },
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        }
       }
     },
     "debug": {
@@ -13330,6 +13939,82 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
+    },
+    "default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "peer": true,
+      "requires": {
+        "execa": "^7.1.1"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "peer": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+          "peer": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "peer": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "peer": true
+        },
+        "npm-run-path": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+          "peer": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "peer": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "peer": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "peer": true
+        }
+      }
     },
     "define-properties": {
       "version": "1.2.0",
@@ -13581,19 +14266,18 @@
       }
     },
     "eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
+      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/eslintrc": "^2.1.1",
+        "@eslint/js": "^8.46.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -13601,7 +14285,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
+        "eslint-visitor-keys": "^3.4.2",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -13708,10 +14392,28 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
       "dev": true
     },
     "espree": {
@@ -13817,9 +14519,9 @@
       }
     },
     "fast-check": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.16.0.tgz",
-      "integrity": "sha512-k8GtQHi4pJoRQ1gVDFQno+/FVkowo/ehiz/aCj9O/D7HRWb1sSFzNrw+iPVU8QlWtH+jNwbuN+dDVg3QkS56DQ==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
       "peer": true,
       "requires": {
         "pure-rand": "^6.0.0"
@@ -13838,9 +14540,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -14014,6 +14716,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
+      "peer": true
+    },
     "fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -14107,8 +14815,7 @@
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -14163,9 +14870,9 @@
       }
     },
     "globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -14406,12 +15113,29 @@
       "requires": {
         "interface-store": "^5.0.0",
         "uint8arrays": "^5.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "interface-store": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
-      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
+      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ==",
       "peer": true
     },
     "internal-slot": {
@@ -14424,6 +15148,18 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "peer": true
+    },
+    "ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "peer": true
     },
     "is-array-buffer": {
       "version": "3.0.2",
@@ -14529,6 +15265,12 @@
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
+    },
+    "is-network-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.0.1.tgz",
+      "integrity": "sha512-OwQXkwBJeESyhFw+OumbJVD58BFBJJI5OM5S1+eyrDKlgDZPX2XNT5gXS56GSD3NPbbwUuMlR1Q71SRp5SobuQ==",
+      "peer": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -14642,8 +15384,13 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "peer": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -14710,6 +15457,16 @@
       "integrity": "sha512-UMiy0i9DqCHBdWvMbzdYvVGa5/w4t1cc4nchpbnjdLhklglv8mQeEYnii0gvKESJuL1zV32Cqdb33R6/GPfxpQ==",
       "peer": true
     },
+    "it-batched-bytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-2.0.5.tgz",
+      "integrity": "sha512-2VgeZ+7KPef0SD2ZgkZfWFe+sgZKdxkzNZXbsYG44nGe4NzWSZLJ6lUjkKHW/S5pSKyW88uacosz6B6K++1LDA==",
+      "peer": true,
+      "requires": {
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
+    },
     "it-byte-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.0.8.tgz",
@@ -14743,6 +15500,19 @@
       "integrity": "sha512-FtQl84iTNxN5EItP/JgL28V2rzNMkCzTUlNoj41eVdfix2z1DBuLnBqZ0hzYhGGa1rMpbQf0M7CQSA2adlrLJg==",
       "peer": true
     },
+    "it-handshake": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
+      "peer": true,
+      "requires": {
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.0.0"
+      }
+    },
     "it-length-prefixed": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.4.tgz",
@@ -14755,6 +15525,23 @@
         "uint8-varint": "^2.0.1",
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^5.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "it-length-prefixed-stream": {
@@ -14876,15 +15663,16 @@
       "peer": true
     },
     "it-ws": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.1.tgz",
-      "integrity": "sha512-oyk4eCeZto2lzWDnJOa3j1S2M+VOGKUh8isEf94ySoaL6IFlyie0T4P9E0ZUaIvX8LyJxYFHFKCt8Zk7Sm/XPQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.0.5.tgz",
+      "integrity": "sha512-xp7tF4fHgx8+vN3Qy/8wGiWUKbC9E1U1g9PwtlbdxD7pY4zld71ZyWZVFHLxnxxg14T9mVNK5uO7U9HK11VQ5g==",
       "peer": true,
       "requires": {
         "@types/ws": "^8.2.2",
         "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
         "it-stream-types": "^2.0.1",
-        "uint8arrays": "^5.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       }
     },
@@ -15985,48 +16773,56 @@
       }
     },
     "libp2p": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-1.2.4.tgz",
-      "integrity": "sha512-K3Hc4Ty0zTS0+CHgM7w1d66kDV6GHJnSlZWkSBEQdnpQ+TiEdRDeT0+Ie3bIaAQlSzEWVuqda5mW4dzl1V6EcQ==",
+      "version": "0.46.21",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.46.21.tgz",
+      "integrity": "sha512-p/3vCpw+ciizhlBofpzuez+4Fs8EeVFaVQZUQPwnQwycuOFcWLBhcqkOtv4KlqImFKOk+9TuyW1Xofjmr/wPnA==",
       "peer": true,
       "requires": {
-        "@libp2p/crypto": "^4.0.3",
-        "@libp2p/interface": "^1.1.4",
-        "@libp2p/interface-internal": "^1.0.9",
-        "@libp2p/logger": "^4.0.7",
-        "@libp2p/multistream-select": "^5.1.4",
-        "@libp2p/peer-collections": "^5.1.7",
-        "@libp2p/peer-id": "^4.0.7",
-        "@libp2p/peer-id-factory": "^4.0.7",
-        "@libp2p/peer-store": "^10.0.11",
-        "@libp2p/utils": "^5.2.6",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@achingbrain/nat-port-mapper": "^1.0.9",
+        "@libp2p/crypto": "^2.0.8",
+        "@libp2p/interface": "^0.1.6",
+        "@libp2p/interface-internal": "^0.1.9",
+        "@libp2p/keychain": "^3.0.8",
+        "@libp2p/logger": "^3.1.0",
+        "@libp2p/multistream-select": "^4.0.6",
+        "@libp2p/peer-collections": "^4.0.8",
+        "@libp2p/peer-id": "^3.0.6",
+        "@libp2p/peer-id-factory": "^3.0.8",
+        "@libp2p/peer-record": "^6.0.9",
+        "@libp2p/peer-store": "^9.0.9",
+        "@libp2p/utils": "^4.0.7",
+        "@multiformats/mafmt": "^12.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-matcher": "^1.0.0",
         "any-signal": "^4.1.1",
-        "datastore-core": "^9.2.8",
-        "interface-datastore": "^8.2.11",
-        "it-merge": "^3.0.3",
-        "it-parallel": "^3.0.6",
+        "datastore-core": "^9.0.1",
+        "delay": "^6.0.0",
+        "interface-datastore": "^8.2.0",
+        "it-all": "^3.0.2",
+        "it-drain": "^3.0.2",
+        "it-filter": "^3.0.1",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-map": "^3.0.3",
+        "it-merge": "^3.0.0",
+        "it-pair": "^2.0.6",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^3.0.1",
+        "it-protobuf-stream": "^1.0.0",
+        "it-stream-types": "^2.0.1",
         "merge-options": "^3.0.4",
-        "multiformats": "^13.1.0",
-        "uint8arrays": "^5.0.2"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.3.tgz",
-          "integrity": "sha512-UT11dl5Bxi9gyXXSyoIfi+7USk2S+46mY9W3t435tS9Y83BeFcdSLAmuiHaKZB/gtnngKfTdjUqEsPSOc79d+w==",
-          "peer": true,
-          "requires": {
-            "@libp2p/interface": "^1.1.4",
-            "@noble/curves": "^1.3.0",
-            "@noble/hashes": "^1.3.3",
-            "asn1js": "^3.0.5",
-            "multiformats": "^13.1.0",
-            "protons-runtime": "^5.4.0",
-            "uint8arraylist": "^2.4.8",
-            "uint8arrays": "^5.0.2"
-          }
-        }
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "p-queue": "^7.3.4",
+        "p-retry": "^6.0.0",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^5.0.0",
+        "rate-limiter-flexible": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6",
+        "wherearewe": "^2.0.1",
+        "xsalsa20": "^1.1.0"
       }
     },
     "lines-and-columns": {
@@ -16047,14 +16843,19 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "peer": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -16121,8 +16922,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -16191,6 +16991,18 @@
         "observable-webworkers": "^2.0.1",
         "p-queue": "^8.0.1",
         "p-timeout": "^6.0.0"
+      },
+      "dependencies": {
+        "p-queue": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+          "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+          "peer": true,
+          "requires": {
+            "eventemitter3": "^5.0.1",
+            "p-timeout": "^6.1.2"
+          }
+        }
       }
     },
     "ms": {
@@ -16199,15 +17011,21 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "peer": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "netmask": {
@@ -16404,9 +17222,9 @@
       "peer": true
     },
     "p-event": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
-      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+      "integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
       "peer": true,
       "requires": {
         "p-timeout": "^6.1.2"
@@ -16431,13 +17249,32 @@
       }
     },
     "p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
       "peer": true,
       "requires": {
         "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "p-timeout": "^5.0.2"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+          "peer": true
+        }
+      }
+    },
+    "p-retry": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+      "peer": true,
+      "requires": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
       }
     },
     "p-timeout": {
@@ -16497,8 +17334,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -16608,6 +17444,12 @@
         }
       }
     },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "peer": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -16648,6 +17490,18 @@
         }
       }
     },
+    "private-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.1.tgz",
+      "integrity": "sha512-Ezc16ANuhSHmWAE6lbXUKburNzGpR0J5X0Zh5Um/PZ/s57Fp+HYqYe6BYPH2QbqKr/5WebfzJQ1jq6Kj5dbRmA==",
+      "peer": true,
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.1.0",
+        "netmask": "^2.0.2"
+      }
+    },
     "progress-events": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
@@ -16683,6 +17537,26 @@
         }
       }
     },
+    "protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "peer": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      }
+    },
     "protons-runtime": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
@@ -16692,6 +17566,23 @@
         "uint8-varint": "^2.0.2",
         "uint8arraylist": "^2.4.3",
         "uint8arrays": "^5.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "psl": {
@@ -16711,21 +17602,6 @@
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
       "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ=="
     },
-    "pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.6.1"
-      }
-    },
-    "pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "peer": true
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -16738,16 +17614,10 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "race-event": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.2.0.tgz",
-      "integrity": "sha512-7EvAjTu9uuKa03Jky8yfSy6/SnnMTh6nouNmdeWv9b0dT8eDZC5ylx30cOR9YO9otQorVjjkIuSHQ5Ml/bKwMw==",
-      "peer": true
-    },
     "race-signal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.2.tgz",
-      "integrity": "sha512-o3xNv0iTcIDQCXFlF6fPAMEBRjFxssgGoRqLbg06m+AdzEXXLUmoNOoUHTVz2NoBI8hHwKFKoC6IqyNtWr2bww==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
+      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw==",
       "peer": true
     },
     "randombytes": {
@@ -16758,6 +17628,12 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "rate-limiter-flexible": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-3.0.6.tgz",
+      "integrity": "sha512-tlvbee6lyse/XTWmsuBDS4MT8N65FyM151bPmQlFyfhv9+RIHs7d3rSTXoz0j35H910dM01mH0yTIeWYo8+aAw==",
+      "peer": true
     },
     "react": {
       "version": "18.2.0",
@@ -16937,6 +17813,12 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "peer": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -17131,6 +18013,21 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "peer": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "peer": true
+    },
     "saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -17179,7 +18076,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -17187,8 +18083,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -17204,8 +18099,7 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -17534,17 +18428,37 @@
         "punycode": "^2.1.1"
       }
     },
-    "ts-api-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-      "dev": true,
-      "requires": {}
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "peer": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
     },
     "tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
     },
     "type-check": {
       "version": "0.4.0",
@@ -17627,6 +18541,23 @@
       "requires": {
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^5.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "uint8arraylist": {
@@ -17636,15 +18567,32 @@
       "peer": true,
       "requires": {
         "uint8arrays": "^5.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+          "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==",
+          "peer": true
+        },
+        "uint8arrays": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
+          "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+          "peer": true,
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
+        }
       }
     },
     "uint8arrays": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.2.tgz",
-      "integrity": "sha512-S0GaeR+orZt7LaqzTRs4ZP8QqzAauJ+0d4xvP2lJTA99jIkKsE2FgDs4tGF/K/z5O9I/2W5Yvrh7IuqNeYH+0Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
+      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
       "peer": true,
       "requires": {
-        "multiformats": "^13.0.0"
+        "multiformats": "^12.0.1"
       }
     },
     "unbox-primitive": {
@@ -17693,6 +18641,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
+      "peer": true
     },
     "utf8-bytes": {
       "version": "0.0.1",
@@ -17815,7 +18769,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -17874,9 +18827,9 @@
       }
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "requires": {}
     },
     "xml-name-validator": {
@@ -17885,11 +18838,33 @@
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "peer": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "peer": true
+    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==",
+      "peer": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "@types/jest": "^29.4.0",
     "@types/react": "^18.0.28",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "@typescript-eslint/eslint-plugin": "^7.1.1",
-    "@typescript-eslint/parser": "^7.1.1",
+    "@typescript-eslint/eslint-plugin": "^5.52.0",
     "bundlewatch": "^0.3.3",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.6.0",
@@ -87,8 +86,8 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@waku/interfaces": "^0.0.22",
-    "@waku/sdk": "^0.0.23",
+    "@waku/sdk": "^0.0.22",
+    "@waku/interfaces": "^0.0.21",
     "react": "^16.8.0 || ^17 || ^18"
   },
   "peerDependenciesMeta": {

--- a/src/WakuProvider.tsx
+++ b/src/WakuProvider.tsx
@@ -3,13 +3,14 @@ import type { Waku } from "@waku/interfaces";
 
 import type {
   BootstrapNodeOptions,
-  CreateNodeResult,
-  CreateWakuNodeOptions,
+  CrateNodeResult,
+  LightNodeOptions,
   ReactChildrenProps,
+  RelayNodeOptions,
 } from "./types";
-import { useCreateLightNode } from "./useCreateWaku";
+import { useCreateLightNode, useCreateRelayNode } from "./useCreateWaku";
 
-type WakuContextType<T extends Waku> = CreateNodeResult<T>;
+type WakuContextType<T extends Waku> = CrateNodeResult<T>;
 
 const WakuContext = React.createContext<WakuContextType<Waku>>({
   node: undefined,
@@ -47,14 +48,44 @@ type ProviderProps<T> = ReactChildrenProps & BootstrapNodeOptions<T>;
  *  ...
  * };
  * @param {Object} props - options to create a node and other React props
- * @param {CreateWakuNodeOptions} props.options - optional options for creating Light Node
+ * @param {LightNodeOptions} props.options - optional options for creating Light Node
  * @param {Protocols} props.protocols - optional protocols list to initiate node with
  * @returns React Light Node provider component
  */
 export const LightNodeProvider: React.FunctionComponent<
-  ProviderProps<CreateWakuNodeOptions>
+  ProviderProps<LightNodeOptions>
 > = (props) => {
   const result = useCreateLightNode({
+    options: props.options,
+    protocols: props.protocols,
+  });
+
+  return (
+    <WakuContext.Provider value={result}>{props.children}</WakuContext.Provider>
+  );
+};
+
+/**
+ * Provider for creating Relay Node based on options passed.
+ * @example
+ * const App = (props) => (
+ *  <RelayNodeProvider options={{...}}>
+ *      <Component />
+ *  </RelayNodeProvider>
+ * );
+ * const Component = (props) => {
+ *  const { node, isLoading, error } = useWaku<RelayNode>();
+ *  ...
+ * };
+ * @param {Object} props - options to create a node and other React props
+ * @param {RelayNodeOptions} props.options - optional options for creating Relay Node
+ * @param {Protocols} props.protocols - optional protocols list to initiate node with
+ * @returns React Relay Node provider component
+ */
+export const RelayNodeProvider: React.FunctionComponent<
+  ProviderProps<RelayNodeOptions>
+> = (props) => {
+  const result = useCreateRelayNode({
     options: props.options,
     protocols: props.protocols,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export { ContentPairProvider, useContentPair } from "./ContentPairProvider";
-export { CreateWakuNodeOptions } from "./types";
+export { LightNodeOptions, RelayNodeOptions } from "./types";
 export { useCreateContentPair } from "./useCreatContentPair";
-export { useCreateLightNode } from "./useCreateWaku";
+export { useCreateLightNode, useCreateRelayNode } from "./useCreateWaku";
 export { useFilterMessages } from "./useFilterMessages";
 export { useLightPush } from "./useLightPush";
 export { useStoreMessages } from "./useStoreMessages";
-export { LightNodeProvider, useWaku } from "./WakuProvider";
+export { LightNodeProvider, RelayNodeProvider, useWaku } from "./WakuProvider";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,12 @@
-import type { Protocols, Waku } from "@waku/interfaces";
-import type { waku } from "@waku/sdk";
-export type { CreateWakuNodeOptions } from "@waku/sdk";
+import type { ProtocolCreateOptions, Protocols, Waku } from "@waku/interfaces";
+import type { relay, waku } from "@waku/sdk";
 
 export type HookState = {
   isLoading: boolean;
   error: undefined | string;
 };
 
-export type CreateNodeResult<T extends Waku> = HookState & {
+export type CrateNodeResult<T extends Waku> = HookState & {
   node: undefined | T;
 };
 
@@ -15,6 +14,11 @@ export type BootstrapNodeOptions<T = {}> = {
   options?: T;
   protocols?: Protocols[];
 };
+
+export type LightNodeOptions = ProtocolCreateOptions & waku.WakuOptions;
+export type RelayNodeOptions = ProtocolCreateOptions &
+  waku.WakuOptions &
+  Partial<relay.RelayCreateOptions>;
 
 export type ContentPair = {
   encoder: waku.Encoder;

--- a/src/useCreateWaku.ts
+++ b/src/useCreateWaku.ts
@@ -1,11 +1,12 @@
 import React from "react";
-import type { LightNode, Waku } from "@waku/interfaces";
-import { createLightNode, waitForRemotePeer } from "@waku/sdk";
+import type { LightNode, RelayNode, Waku } from "@waku/interfaces";
+import { createLightNode, createRelayNode, waitForRemotePeer } from "@waku/sdk";
 
 import type {
   BootstrapNodeOptions,
-  CreateNodeResult,
-  CreateWakuNodeOptions,
+  CrateNodeResult,
+  LightNodeOptions,
+  RelayNodeOptions,
 } from "./types";
 
 type NodeFactory<N, T = {}> = (options?: T) => Promise<N>;
@@ -16,7 +17,7 @@ type CreateNodeParams<N extends Waku, T = {}> = BootstrapNodeOptions<T> & {
 
 const useCreateNode = <N extends Waku, T = {}>(
   params: CreateNodeParams<N, T>,
-): CreateNodeResult<N> => {
+): CrateNodeResult<N> => {
   const { factory, options, protocols = [] } = params;
 
   const [node, setNode] = React.useState<N | undefined>(undefined);
@@ -63,10 +64,24 @@ const useCreateNode = <N extends Waku, T = {}>(
  * @returns {CrateWakuHook} node, loading state and error
  */
 export const useCreateLightNode = (
-  params?: BootstrapNodeOptions<CreateWakuNodeOptions>,
+  params?: BootstrapNodeOptions<LightNodeOptions>,
 ) => {
-  return useCreateNode<LightNode, CreateWakuNodeOptions>({
+  return useCreateNode<LightNode, LightNodeOptions>({
     ...params,
     factory: createLightNode,
+  });
+};
+
+/**
+ * Create Relay Node helper hook.
+ * @param {Object} params - optional params to configure & bootstrap node
+ * @returns {CrateWakuHook} node, loading state and error
+ */
+export const useCreateRelayNode = (
+  params?: BootstrapNodeOptions<RelayNodeOptions>,
+) => {
+  return useCreateNode<RelayNode, RelayNodeOptions>({
+    ...params,
+    factory: createRelayNode,
   });
 };


### PR DESCRIPTION
Reverts waku-org/waku-react#39:

When installing `@waku/react`, the types are not being installed implicitly.

Rolling back for now, and open two separate PRs to
1. upgrade
2. remove relay node

cc @adklempner 