### PR TITLE
chore: fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "umd:main": "dist/index.umd.js",
   "unpkg": "dist/index.umd.js",
   "source": "src/index.ts",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",


### PR DESCRIPTION
The latest release had types being generated in `/src/` but the path was not updated in package.json leading to breaking type imports.